### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Investopedia Bot that is able to generate consistent positive returns by exploit
 
 
 Add Options trading
+
+### Run it
+
+[![Run on Repl.it](https://repl.it/badge/github/theriley106/Wolf_of_Investopedia)](https://repl.it/github/theriley106/Wolf_of_Investopedia)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pieromqwerty/WolfofInvestopedia).